### PR TITLE
Micropython 1.24.1 compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Module.symvers
 Mkfile.old
 dkms.conf
 .DS_Store
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Originally from https://github.com/diybitcoinhardware/f469-disco/tree/master/use
 
 extends `hashlib` micropython module with `ripemd160` and `sha512` functions.
 
-Also adds a single-line function for pbkdf2_hmac:
+Also adds a single-line function for pbkdf2_hmac (supports sha256 or sha512):
 
 `pbkdf2_hmac(hash_name, password, salt, iterations, bytes_to_read)`
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Originally from https://github.com/diybitcoinhardware/f469-disco/tree/master/use
 
 extends `hashlib` micropython module with `ripemd160` and `sha512` functions.
 
-Also adds a single-line function for pbkdf2_hmac_sha512:
+Also adds a single-line function for pbkdf2_hmac:
 
-`pbkdf2_hmac_sha512(password, salt, iterations, bytes_to_read)`
+`pbkdf2_hmac(hash_name, password, salt, iterations, bytes_to_read)`
 
 in Bitcoin to generate a seed:
 
-`pbkdf2_hmac_sha512(mnemonic, 'mnemonic'+password, 2048, 64)`
+`pbkdf2_hmac('sha512', mnemonic, 'mnemonic'+password, 2048, 64)`
 
 ## TODO:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Hash functions for Bitcoin
 
+Originally from https://github.com/diybitcoinhardware/f469-disco/tree/master/usermods/uhashlib
+
+---
+
 extends `hashlib` micropython module with `ripemd160` and `sha512` functions.
 
 Also adds a single-line function for pbkdf2_hmac_sha512:

--- a/crypto/sha2.c
+++ b/crypto/sha2.c
@@ -577,7 +577,7 @@ void sha1_Update(SHA1_CTX* context, const sha2_byte *data, size_t len) {
 	usedspace = freespace = 0;
 }
 
-void sha1_Final(SHA1_CTX* context, sha2_byte digest[]) {
+void sha1_Final(SHA1_CTX* context, sha2_byte digest[SHA1_DIGEST_LENGTH]) {
 	unsigned int	usedspace;
 
 	/* If no digest buffer is passed, we don't bother doing this: */
@@ -631,7 +631,7 @@ void sha1_Final(SHA1_CTX* context, sha2_byte digest[]) {
 	usedspace = 0;
 }
 
-char *sha1_End(SHA1_CTX* context, char buffer[]) {
+char *sha1_End(SHA1_CTX* context, char buffer[SHA1_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA1_DIGEST_LENGTH], *d = digest;
 	int		i;
 
@@ -884,7 +884,7 @@ void sha256_Update(SHA256_CTX* context, const sha2_byte *data, size_t len) {
 	usedspace = freespace = 0;
 }
 
-void sha256_Final(SHA256_CTX* context, sha2_byte digest[]) {
+void sha256_Final(SHA256_CTX* context, sha2_byte digest[SHA256_DIGEST_LENGTH]) {
 	unsigned int	usedspace;
 
 	/* If no digest buffer is passed, we don't bother doing this: */
@@ -938,7 +938,7 @@ void sha256_Final(SHA256_CTX* context, sha2_byte digest[]) {
 	usedspace = 0;
 }
 
-char *sha256_End(SHA256_CTX* context, char buffer[]) {
+char *sha256_End(SHA256_CTX* context, char buffer[SHA256_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA256_DIGEST_LENGTH], *d = digest;
 	int		i;
 
@@ -1228,7 +1228,7 @@ static void sha512_Last(SHA512_CTX* context) {
 	sha512_Transform(context->state, context->buffer, context->state);
 }
 
-void sha512_Final(SHA512_CTX* context, sha2_byte digest[]) {
+void sha512_Final(SHA512_CTX* context, sha2_byte digest[SHA512_DIGEST_LENGTH]) {
 	/* If no digest buffer is passed, we don't bother doing this: */
 	if (digest != (sha2_byte*)0) {
 		sha512_Last(context);
@@ -1247,7 +1247,7 @@ void sha512_Final(SHA512_CTX* context, sha2_byte digest[]) {
 	memzero(context, sizeof(SHA512_CTX));
 }
 
-char *sha512_End(SHA512_CTX* context, char buffer[]) {
+char *sha512_End(SHA512_CTX* context, char buffer[SHA512_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA512_DIGEST_LENGTH], *d = digest;
 	int		i;
 

--- a/hashlib.c
+++ b/hashlib.c
@@ -49,7 +49,7 @@ static mp_obj_t hashlib_sha1_digest(mp_obj_t self_in) {
     vstr_t vstr;
     vstr_init_len(&vstr, SHA1_DIGEST_LENGTH);
     sha1_Final((SHA1_CTX*)self->state, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 static MP_DEFINE_CONST_FUN_OBJ_2(hashlib_sha1_update_obj, hashlib_sha1_update);
@@ -118,7 +118,7 @@ static mp_obj_t hashlib_sha256_digest(mp_obj_t self_in) {
     vstr_t vstr;
     vstr_init_len(&vstr, SHA256_DIGEST_LENGTH);
     sha256_Final((SHA256_CTX*)self->state, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 static MP_DEFINE_CONST_FUN_OBJ_2(hashlib_sha256_update_obj, hashlib_sha256_update);
@@ -186,7 +186,7 @@ static mp_obj_t hashlib_sha512_digest(mp_obj_t self_in) {
     vstr_t vstr;
     vstr_init_len(&vstr, SHA512_DIGEST_LENGTH);
     sha512_Final((SHA512_CTX*)self->state, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 static MP_DEFINE_CONST_FUN_OBJ_2(hashlib_sha512_update_obj, hashlib_sha512_update);
@@ -255,7 +255,7 @@ static mp_obj_t hashlib_ripemd160_digest(mp_obj_t self_in) {
     vstr_t vstr;
     vstr_init_len(&vstr, RIPEMD160_DIGEST_LENGTH);
     ripemd160_Final((RIPEMD160_CTX*)self->state, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 static MP_DEFINE_CONST_FUN_OBJ_2(hashlib_ripemd160_update_obj, hashlib_ripemd160_update);
@@ -314,7 +314,7 @@ static mp_obj_t hashlib_pbkdf2_hmac(size_t n_args, const mp_obj_t *args) {
         vstr_t vstr;
         vstr_init_len(&vstr, l);
         pbkdf2_hmac_sha256(pwdbuf.buf, pwdbuf.len, saltbuf.buf, saltbuf.len, iter, (byte*)vstr.buf, l);
-        return mp_obj_new_str_from_vstr(&vstr);
+        return mp_obj_new_bytes_from_vstr(&vstr);
     }
     if(strcmp(typebuf.buf, "sha512") == 0){
         // output length (dklen) if available
@@ -325,7 +325,7 @@ static mp_obj_t hashlib_pbkdf2_hmac(size_t n_args, const mp_obj_t *args) {
         vstr_t vstr;
         vstr_init_len(&vstr, l);
         pbkdf2_hmac_sha512(pwdbuf.buf, pwdbuf.len, saltbuf.buf, saltbuf.len, iter, (byte*)vstr.buf, l);
-        return mp_obj_new_str_from_vstr(&vstr);
+        return mp_obj_new_bytes_from_vstr(&vstr);
     }
     mp_raise_ValueError("Unsupported hash type");
     return mp_const_none;
@@ -343,7 +343,7 @@ static mp_obj_t hashlib_hmac_sha512(mp_uint_t n_args, const mp_obj_t *args){
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     hmac_sha512_oneline(keybuf.buf, keybuf.len, msgbuf.buf, msgbuf.len, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 static MP_DEFINE_CONST_FUN_OBJ_VAR(hashlib_hmac_sha512_obj, 2, hashlib_hmac_sha512);

--- a/hashlib.c
+++ b/hashlib.c
@@ -15,11 +15,11 @@ typedef struct _mp_obj_hash_t {
 
 /****************************** SHA1 ******************************/
 
-STATIC mp_obj_t hashlib_sha1_update(mp_obj_t self_in, mp_obj_t arg);
+static mp_obj_t hashlib_sha1_update(mp_obj_t self_in, mp_obj_t arg);
 
-STATIC mp_obj_t hashlib_sha1_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hashlib_sha1_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(SHA1_CTX));
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA1_CTX));
     o->base.type = type;
     sha1_Init((SHA1_CTX*)o->state);
     if (n_args == 1) {
@@ -28,15 +28,15 @@ STATIC mp_obj_t hashlib_sha1_make_new(const mp_obj_type_t *type, size_t n_args, 
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hashlib_sha1_copy(mp_obj_t self_in) {
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(SHA1_CTX));
+static mp_obj_t hashlib_sha1_copy(mp_obj_t self_in) {
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA1_CTX));
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     o->base.type = self->base.type;
     memcpy(o->state, self->state, sizeof(SHA1_CTX));
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hashlib_sha1_update(mp_obj_t self_in, mp_obj_t arg) {
+static mp_obj_t hashlib_sha1_update(mp_obj_t self_in, mp_obj_t arg) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(arg, &bufinfo, MP_BUFFER_READ);
@@ -44,19 +44,19 @@ STATIC mp_obj_t hashlib_sha1_update(mp_obj_t self_in, mp_obj_t arg) {
     return mp_const_none;
 }
 
-STATIC mp_obj_t hashlib_sha1_digest(mp_obj_t self_in) {
+static mp_obj_t hashlib_sha1_digest(mp_obj_t self_in) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     vstr_t vstr;
     vstr_init_len(&vstr, SHA1_DIGEST_LENGTH);
     sha1_Final((SHA1_CTX*)self->state, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_str_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(hashlib_sha1_update_obj, hashlib_sha1_update);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha1_digest_obj, hashlib_sha1_digest);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha1_copy_obj, hashlib_sha1_copy);
+static MP_DEFINE_CONST_FUN_OBJ_2(hashlib_sha1_update_obj, hashlib_sha1_update);
+static MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha1_digest_obj, hashlib_sha1_digest);
+static MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha1_copy_obj, hashlib_sha1_copy);
 
-STATIC const mp_rom_map_elem_t hashlib_sha1_locals_dict_table[] = {
+static const mp_rom_map_elem_t hashlib_sha1_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&hashlib_sha1_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest), MP_ROM_PTR(&hashlib_sha1_digest_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest_size), MP_ROM_INT(SHA1_DIGEST_LENGTH) },
@@ -64,9 +64,9 @@ STATIC const mp_rom_map_elem_t hashlib_sha1_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_copy), MP_ROM_PTR(&hashlib_sha1_copy_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(hashlib_sha1_locals_dict, hashlib_sha1_locals_dict_table);
+static MP_DEFINE_CONST_DICT(hashlib_sha1_locals_dict, hashlib_sha1_locals_dict_table);
 
-STATIC const mp_obj_type_t hashlib_sha1_type = {
+static const mp_obj_type_t hashlib_sha1_type = {
     { &mp_type_type },
     .name = MP_QSTR_sha1,
     .make_new = hashlib_sha1_make_new,
@@ -75,11 +75,11 @@ STATIC const mp_obj_type_t hashlib_sha1_type = {
 
 /****************************** SHA256 ******************************/
 
-STATIC mp_obj_t hashlib_sha256_update(mp_obj_t self_in, mp_obj_t arg);
+static mp_obj_t hashlib_sha256_update(mp_obj_t self_in, mp_obj_t arg);
 
-STATIC mp_obj_t hashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(SHA256_CTX));
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA256_CTX));
     o->base.type = type;
     sha256_Init((SHA256_CTX*)o->state);
     if (n_args == 1) {
@@ -88,15 +88,15 @@ STATIC mp_obj_t hashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hashlib_sha256_copy(mp_obj_t self_in) {
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(SHA256_CTX));
+static mp_obj_t hashlib_sha256_copy(mp_obj_t self_in) {
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA256_CTX));
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     o->base.type = self->base.type;
     memcpy(o->state, self->state, sizeof(SHA256_CTX));
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hashlib_sha256_update(mp_obj_t self_in, mp_obj_t arg) {
+static mp_obj_t hashlib_sha256_update(mp_obj_t self_in, mp_obj_t arg) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(arg, &bufinfo, MP_BUFFER_READ);
@@ -104,19 +104,19 @@ STATIC mp_obj_t hashlib_sha256_update(mp_obj_t self_in, mp_obj_t arg) {
     return mp_const_none;
 }
 
-STATIC mp_obj_t hashlib_sha256_digest(mp_obj_t self_in) {
+static mp_obj_t hashlib_sha256_digest(mp_obj_t self_in) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     vstr_t vstr;
     vstr_init_len(&vstr, SHA256_DIGEST_LENGTH);
     sha256_Final((SHA256_CTX*)self->state, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_str_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(hashlib_sha256_update_obj, hashlib_sha256_update);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha256_digest_obj, hashlib_sha256_digest);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha256_copy_obj, hashlib_sha256_copy);
+static MP_DEFINE_CONST_FUN_OBJ_2(hashlib_sha256_update_obj, hashlib_sha256_update);
+static MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha256_digest_obj, hashlib_sha256_digest);
+static MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha256_copy_obj, hashlib_sha256_copy);
 
-STATIC const mp_rom_map_elem_t hashlib_sha256_locals_dict_table[] = {
+static const mp_rom_map_elem_t hashlib_sha256_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&hashlib_sha256_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest), MP_ROM_PTR(&hashlib_sha256_digest_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest_size), MP_ROM_INT(SHA256_DIGEST_LENGTH) },
@@ -124,9 +124,9 @@ STATIC const mp_rom_map_elem_t hashlib_sha256_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_copy), MP_ROM_PTR(&hashlib_sha256_copy_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(hashlib_sha256_locals_dict, hashlib_sha256_locals_dict_table);
+static MP_DEFINE_CONST_DICT(hashlib_sha256_locals_dict, hashlib_sha256_locals_dict_table);
 
-STATIC const mp_obj_type_t hashlib_sha256_type = {
+static const mp_obj_type_t hashlib_sha256_type = {
     { &mp_type_type },
     .name = MP_QSTR_sha256,
     .make_new = hashlib_sha256_make_new,
@@ -135,11 +135,11 @@ STATIC const mp_obj_type_t hashlib_sha256_type = {
 
 /****************************** SHA512 ******************************/
 
-STATIC mp_obj_t hashlib_sha512_update(mp_obj_t self_in, mp_obj_t arg);
+static mp_obj_t hashlib_sha512_update(mp_obj_t self_in, mp_obj_t arg);
 
-STATIC mp_obj_t hashlib_sha512_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hashlib_sha512_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(SHA512_CTX));
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA512_CTX));
     o->base.type = type;
     sha512_Init((SHA512_CTX*)o->state);
     if (n_args == 1) {
@@ -148,15 +148,15 @@ STATIC mp_obj_t hashlib_sha512_make_new(const mp_obj_type_t *type, size_t n_args
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hashlib_sha512_copy(mp_obj_t self_in) {
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(SHA512_CTX));
+static mp_obj_t hashlib_sha512_copy(mp_obj_t self_in) {
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA512_CTX));
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     o->base.type = self->base.type;
     memcpy(o->state, self->state, sizeof(SHA512_CTX));
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hashlib_sha512_update(mp_obj_t self_in, mp_obj_t arg) {
+static mp_obj_t hashlib_sha512_update(mp_obj_t self_in, mp_obj_t arg) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(arg, &bufinfo, MP_BUFFER_READ);
@@ -164,19 +164,19 @@ STATIC mp_obj_t hashlib_sha512_update(mp_obj_t self_in, mp_obj_t arg) {
     return mp_const_none;
 }
 
-STATIC mp_obj_t hashlib_sha512_digest(mp_obj_t self_in) {
+static mp_obj_t hashlib_sha512_digest(mp_obj_t self_in) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     vstr_t vstr;
     vstr_init_len(&vstr, SHA512_DIGEST_LENGTH);
     sha512_Final((SHA512_CTX*)self->state, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_str_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(hashlib_sha512_update_obj, hashlib_sha512_update);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha512_digest_obj, hashlib_sha512_digest);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha512_copy_obj, hashlib_sha512_copy);
+static MP_DEFINE_CONST_FUN_OBJ_2(hashlib_sha512_update_obj, hashlib_sha512_update);
+static MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha512_digest_obj, hashlib_sha512_digest);
+static MP_DEFINE_CONST_FUN_OBJ_1(hashlib_sha512_copy_obj, hashlib_sha512_copy);
 
-STATIC const mp_rom_map_elem_t hashlib_sha512_locals_dict_table[] = {
+static const mp_rom_map_elem_t hashlib_sha512_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&hashlib_sha512_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest), MP_ROM_PTR(&hashlib_sha512_digest_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest_size), MP_ROM_INT(SHA512_DIGEST_LENGTH) },
@@ -184,9 +184,9 @@ STATIC const mp_rom_map_elem_t hashlib_sha512_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_copy), MP_ROM_PTR(&hashlib_sha512_copy_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(hashlib_sha512_locals_dict, hashlib_sha512_locals_dict_table);
+static MP_DEFINE_CONST_DICT(hashlib_sha512_locals_dict, hashlib_sha512_locals_dict_table);
 
-STATIC const mp_obj_type_t hashlib_sha512_type = {
+static const mp_obj_type_t hashlib_sha512_type = {
     { &mp_type_type },
     .name = MP_QSTR_sha512,
     .make_new = hashlib_sha512_make_new,
@@ -195,11 +195,11 @@ STATIC const mp_obj_type_t hashlib_sha512_type = {
 
 /****************************** RIPEMD160 ******************************/
 
-STATIC mp_obj_t hashlib_ripemd160_update(mp_obj_t self_in, mp_obj_t arg);
+static mp_obj_t hashlib_ripemd160_update(mp_obj_t self_in, mp_obj_t arg);
 
-STATIC mp_obj_t hashlib_ripemd160_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hashlib_ripemd160_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(RIPEMD160_CTX));
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(RIPEMD160_CTX));
     o->base.type = type;
     ripemd160_Init((RIPEMD160_CTX*)o->state);
     if (n_args == 1) {
@@ -208,15 +208,15 @@ STATIC mp_obj_t hashlib_ripemd160_make_new(const mp_obj_type_t *type, size_t n_a
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hashlib_ripemd160_copy(mp_obj_t self_in) {
-    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(RIPEMD160_CTX));
+static mp_obj_t hashlib_ripemd160_copy(mp_obj_t self_in) {
+    mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(RIPEMD160_CTX));
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     o->base.type = self->base.type;
     memcpy(o->state, self->state, sizeof(RIPEMD160_CTX));
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hashlib_ripemd160_update(mp_obj_t self_in, mp_obj_t arg) {
+static mp_obj_t hashlib_ripemd160_update(mp_obj_t self_in, mp_obj_t arg) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(arg, &bufinfo, MP_BUFFER_READ);
@@ -224,19 +224,19 @@ STATIC mp_obj_t hashlib_ripemd160_update(mp_obj_t self_in, mp_obj_t arg) {
     return mp_const_none;
 }
 
-STATIC mp_obj_t hashlib_ripemd160_digest(mp_obj_t self_in) {
+static mp_obj_t hashlib_ripemd160_digest(mp_obj_t self_in) {
     mp_obj_hash_t *self = MP_OBJ_TO_PTR(self_in);
     vstr_t vstr;
     vstr_init_len(&vstr, RIPEMD160_DIGEST_LENGTH);
     ripemd160_Final((RIPEMD160_CTX*)self->state, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_str_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(hashlib_ripemd160_update_obj, hashlib_ripemd160_update);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hashlib_ripemd160_digest_obj, hashlib_ripemd160_digest);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hashlib_ripemd160_copy_obj, hashlib_ripemd160_copy);
+static MP_DEFINE_CONST_FUN_OBJ_2(hashlib_ripemd160_update_obj, hashlib_ripemd160_update);
+static MP_DEFINE_CONST_FUN_OBJ_1(hashlib_ripemd160_digest_obj, hashlib_ripemd160_digest);
+static MP_DEFINE_CONST_FUN_OBJ_1(hashlib_ripemd160_copy_obj, hashlib_ripemd160_copy);
 
-STATIC const mp_rom_map_elem_t hashlib_ripemd160_locals_dict_table[] = {
+static const mp_rom_map_elem_t hashlib_ripemd160_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&hashlib_ripemd160_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest), MP_ROM_PTR(&hashlib_ripemd160_digest_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest_size), MP_ROM_INT(RIPEMD160_DIGEST_LENGTH) },
@@ -244,9 +244,9 @@ STATIC const mp_rom_map_elem_t hashlib_ripemd160_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_copy), MP_ROM_PTR(&hashlib_ripemd160_copy_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(hashlib_ripemd160_locals_dict, hashlib_ripemd160_locals_dict_table);
+static MP_DEFINE_CONST_DICT(hashlib_ripemd160_locals_dict, hashlib_ripemd160_locals_dict_table);
 
-STATIC const mp_obj_type_t hashlib_ripemd160_type = {
+static const mp_obj_type_t hashlib_ripemd160_type = {
     { &mp_type_type },
     .name = MP_QSTR_ripemd160,
     .make_new = hashlib_ripemd160_make_new,
@@ -256,7 +256,7 @@ STATIC const mp_obj_type_t hashlib_ripemd160_type = {
 /************************** pbkdf2_hmac **************************/
 
 // hashlib.pbkdf2_hmac(hash_name, password, salt, iterations, dklen=None)
-STATIC mp_obj_t hashlib_pbkdf2_hmac(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t hashlib_pbkdf2_hmac(size_t n_args, const mp_obj_t *args) {
     // hash_name
     mp_buffer_info_t typebuf;
     mp_get_buffer_raise(args[0], &typebuf, MP_BUFFER_READ);
@@ -279,7 +279,7 @@ STATIC mp_obj_t hashlib_pbkdf2_hmac(size_t n_args, const mp_obj_t *args) {
         vstr_t vstr;
         vstr_init_len(&vstr, l);
         pbkdf2_hmac_sha256(pwdbuf.buf, pwdbuf.len, saltbuf.buf, saltbuf.len, iter, (byte*)vstr.buf, l);
-        return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+        return mp_obj_new_str_from_vstr(&vstr);
     }
     if(strcmp(typebuf.buf, "sha512") == 0){
         // output length (dklen) if available
@@ -290,16 +290,16 @@ STATIC mp_obj_t hashlib_pbkdf2_hmac(size_t n_args, const mp_obj_t *args) {
         vstr_t vstr;
         vstr_init_len(&vstr, l);
         pbkdf2_hmac_sha512(pwdbuf.buf, pwdbuf.len, saltbuf.buf, saltbuf.len, iter, (byte*)vstr.buf, l);
-        return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+        return mp_obj_new_str_from_vstr(&vstr);
     }
     mp_raise_ValueError("Unsupported hash type");
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(hashlib_pbkdf2_hmac_obj, 4, hashlib_pbkdf2_hmac);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(hashlib_pbkdf2_hmac_obj, 4, hashlib_pbkdf2_hmac);
 
 /************************** hmac_sha512 **************************/
 
-STATIC mp_obj_t hashlib_hmac_sha512(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t hashlib_hmac_sha512(mp_uint_t n_args, const mp_obj_t *args){
     //mp_obj_t key, mp_obj_t msg
     mp_buffer_info_t keybuf;
     mp_get_buffer_raise(args[0], &keybuf, MP_BUFFER_READ);
@@ -308,12 +308,12 @@ STATIC mp_obj_t hashlib_hmac_sha512(mp_uint_t n_args, const mp_obj_t *args){
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     hmac_sha512_oneline(keybuf.buf, keybuf.len, msgbuf.buf, msgbuf.len, (byte*)vstr.buf);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_str_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(hashlib_hmac_sha512_obj, 2, hashlib_hmac_sha512);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(hashlib_hmac_sha512_obj, 2, hashlib_hmac_sha512);
 
-STATIC mp_obj_t hashlib_new(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t hashlib_new(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t typebuf;
     mp_get_buffer_raise(args[0], &typebuf, MP_BUFFER_READ);
     if(strcmp(typebuf.buf, "ripemd160") == 0){
@@ -331,12 +331,12 @@ STATIC mp_obj_t hashlib_new(size_t n_args, const mp_obj_t *args) {
     mp_raise_ValueError("Unsupported hash type");
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(hashlib_new_obj, 1, hashlib_new);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(hashlib_new_obj, 1, hashlib_new);
 
 
 /****************************** MODULE ******************************/
 
-STATIC const mp_rom_map_elem_t hashlib_module_globals_table[] = {
+static const mp_rom_map_elem_t hashlib_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_hashlib) },
     { MP_ROM_QSTR(MP_QSTR_new), MP_ROM_PTR(&hashlib_new_obj) },
     { MP_ROM_QSTR(MP_QSTR_sha1), MP_ROM_PTR(&hashlib_sha1_type) },
@@ -347,11 +347,11 @@ STATIC const mp_rom_map_elem_t hashlib_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_hmac_sha512), MP_ROM_PTR(&hashlib_hmac_sha512_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(hashlib_module_globals, hashlib_module_globals_table);
+static MP_DEFINE_CONST_DICT(hashlib_module_globals, hashlib_module_globals_table);
 
 const mp_obj_module_t hashlib_user_cmodule = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&hashlib_module_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_hashlib, hashlib_user_cmodule, MODULE_HASHLIB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_hashlib, hashlib_user_cmodule);

--- a/hashlib.c
+++ b/hashlib.c
@@ -66,12 +66,21 @@ static const mp_rom_map_elem_t hashlib_sha1_locals_dict_table[] = {
 
 static MP_DEFINE_CONST_DICT(hashlib_sha1_locals_dict, hashlib_sha1_locals_dict_table);
 
-static const mp_obj_type_t hashlib_sha1_type = {
-    { &mp_type_type },
-    .name = MP_QSTR_sha1,
-    .make_new = hashlib_sha1_make_new,
-    .locals_dict = (void*)&hashlib_sha1_locals_dict,
-};
+// static const mp_obj_type_t hashlib_sha1_type = {
+//     { &mp_type_type },
+//     .name = MP_QSTR_sha1,
+//     .make_new = hashlib_sha1_make_new,
+//     .locals_dict = (void*)&hashlib_sha1_locals_dict,
+// };
+
+static MP_DEFINE_CONST_OBJ_TYPE(
+    hashlib_sha1_type,
+    MP_QSTR_sha1,
+    MP_TYPE_FLAG_NONE,
+    make_new, hashlib_sha1_make_new,
+    locals_dict, &hashlib_sha1_locals_dict
+);
+
 
 /****************************** SHA256 ******************************/
 
@@ -126,12 +135,20 @@ static const mp_rom_map_elem_t hashlib_sha256_locals_dict_table[] = {
 
 static MP_DEFINE_CONST_DICT(hashlib_sha256_locals_dict, hashlib_sha256_locals_dict_table);
 
-static const mp_obj_type_t hashlib_sha256_type = {
-    { &mp_type_type },
-    .name = MP_QSTR_sha256,
-    .make_new = hashlib_sha256_make_new,
-    .locals_dict = (void*)&hashlib_sha256_locals_dict,
-};
+// static const mp_obj_type_t hashlib_sha256_type = {
+//     { &mp_type_type },
+//     .name = MP_QSTR_sha256,
+//     .make_new = hashlib_sha256_make_new,
+//     .locals_dict = (void*)&hashlib_sha256_locals_dict,
+// };
+
+static MP_DEFINE_CONST_OBJ_TYPE(
+    hashlib_sha256_type,
+    MP_QSTR_sha256,
+    MP_TYPE_FLAG_NONE,
+    make_new, hashlib_sha256_make_new,
+    locals_dict, &hashlib_sha256_locals_dict
+);
 
 /****************************** SHA512 ******************************/
 
@@ -186,12 +203,21 @@ static const mp_rom_map_elem_t hashlib_sha512_locals_dict_table[] = {
 
 static MP_DEFINE_CONST_DICT(hashlib_sha512_locals_dict, hashlib_sha512_locals_dict_table);
 
-static const mp_obj_type_t hashlib_sha512_type = {
-    { &mp_type_type },
-    .name = MP_QSTR_sha512,
-    .make_new = hashlib_sha512_make_new,
-    .locals_dict = (void*)&hashlib_sha512_locals_dict,
-};
+// static const mp_obj_type_t hashlib_sha512_type = {
+//     { &mp_type_type },
+//     .name = MP_QSTR_sha512,
+//     .make_new = hashlib_sha512_make_new,
+//     .locals_dict = (void*)&hashlib_sha512_locals_dict,
+// };
+
+static MP_DEFINE_CONST_OBJ_TYPE(
+    hashlib_sha512_type,
+    MP_QSTR_sha512,
+    MP_TYPE_FLAG_NONE,
+    make_new, hashlib_sha512_make_new,
+    locals_dict, &hashlib_sha512_locals_dict
+);
+
 
 /****************************** RIPEMD160 ******************************/
 
@@ -246,12 +272,21 @@ static const mp_rom_map_elem_t hashlib_ripemd160_locals_dict_table[] = {
 
 static MP_DEFINE_CONST_DICT(hashlib_ripemd160_locals_dict, hashlib_ripemd160_locals_dict_table);
 
-static const mp_obj_type_t hashlib_ripemd160_type = {
-    { &mp_type_type },
-    .name = MP_QSTR_ripemd160,
-    .make_new = hashlib_ripemd160_make_new,
-    .locals_dict = (void*)&hashlib_ripemd160_locals_dict,
-};
+// static const mp_obj_type_t hashlib_ripemd160_type = {
+//     { &mp_type_type },
+//     .name = MP_QSTR_ripemd160,
+//     .make_new = hashlib_ripemd160_make_new,
+//     .locals_dict = (void*)&hashlib_ripemd160_locals_dict,
+// };
+
+
+static MP_DEFINE_CONST_OBJ_TYPE(
+    hashlib_ripemd160_type,
+    MP_QSTR_ripemd160,
+    MP_TYPE_FLAG_NONE,
+    make_new, hashlib_ripemd160_make_new,
+    locals_dict, &hashlib_ripemd160_locals_dict
+);
 
 /************************** pbkdf2_hmac **************************/
 

--- a/micropython.cmake
+++ b/micropython.cmake
@@ -17,11 +17,12 @@ target_include_directories(hashlib INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}/
     ${CMAKE_CURRENT_LIST_DIR}/crypto
 )
-# target_compile_options(hashlib INTERFACE
-#     -DHAVE_CONFIG_H 
-#     -Wno-unused-function
-#     -Wno-error
-# )
+target_compile_options(hashlib INTERFACE
+    -DHAVE_CONFIG_H 
+    -Wno-unused-function
+    -Wno-error
+    -O2
+)
 
 # Link our INTERFACE library to the usermod target.
 target_link_libraries(usermod INTERFACE hashlib)

--- a/uhmac.c
+++ b/uhmac.c
@@ -17,9 +17,9 @@ typedef struct _mp_obj_hmac_t {
 
 /****************************** HMAC ******************************/
 
-STATIC mp_obj_t hmac_HMAC_update(mp_obj_t self_in, mp_obj_t arg);
+static mp_obj_t hmac_HMAC_update(mp_obj_t self_in, mp_obj_t arg);
 
-STATIC mp_obj_t hmac_HMAC_make_new_helper(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kwargs){
+static mp_obj_t hmac_HMAC_make_new_helper(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kwargs){
     mp_arg_check_num(n_args, 0, 0, 3, true);
 
     enum { ARG_key, ARG_message, ARG_digestmod };
@@ -45,7 +45,7 @@ STATIC mp_obj_t hmac_HMAC_make_new_helper(const mp_obj_type_t *type, size_t n_ar
         return mp_const_none;
     }
 
-    mp_obj_hmac_t *o = m_new_obj_var(mp_obj_hmac_t, char, digestmod+sizeof(size_t));
+    mp_obj_hmac_t *o = m_new_obj_var(mp_obj_hmac_t, state, char, digestmod+sizeof(size_t));
     o->digestmod = digestmod;
     o->base.type = type;
 
@@ -62,7 +62,7 @@ STATIC mp_obj_t hmac_HMAC_make_new_helper(const mp_obj_type_t *type, size_t n_ar
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hmac_HMAC_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t hmac_HMAC_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
 
     mp_map_t kw_args;
@@ -70,16 +70,16 @@ STATIC mp_obj_t hmac_HMAC_make_new(const mp_obj_type_t *type, size_t n_args, siz
     return hmac_HMAC_make_new_helper(type, n_args, args, &kw_args);
 }
 
-STATIC mp_obj_t hmac_HMAC_copy(mp_obj_t self_in) {
+static mp_obj_t hmac_HMAC_copy(mp_obj_t self_in) {
     mp_obj_hmac_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_obj_hmac_t *o = m_new_obj_var(mp_obj_hmac_t, char, self->digestmod+sizeof(size_t));
+    mp_obj_hmac_t *o = m_new_obj_var(mp_obj_hmac_t, state, char, self->digestmod+sizeof(size_t));
     o->base.type = self->base.type;
     o->digestmod = self->digestmod;
     memcpy(o->state, self->state, self->digestmod);
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t hmac_HMAC_update(mp_obj_t self_in, mp_obj_t arg) {
+static mp_obj_t hmac_HMAC_update(mp_obj_t self_in, mp_obj_t arg) {
     mp_obj_hmac_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(arg, &bufinfo, MP_BUFFER_READ);
@@ -91,7 +91,7 @@ STATIC mp_obj_t hmac_HMAC_update(mp_obj_t self_in, mp_obj_t arg) {
     return mp_const_none;
 }
 
-STATIC mp_obj_t hmac_HMAC_digest(mp_obj_t self_in) {
+static mp_obj_t hmac_HMAC_digest(mp_obj_t self_in) {
     mp_obj_hmac_t *self = MP_OBJ_TO_PTR(self_in);
     vstr_t vstr;
     if(self->digestmod == DIGEST_HMAC_SHA256){
@@ -104,19 +104,19 @@ STATIC mp_obj_t hmac_HMAC_digest(mp_obj_t self_in) {
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(hmac_HMAC_update_obj, hmac_HMAC_update);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hmac_HMAC_digest_obj, hmac_HMAC_digest);
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(hmac_HMAC_copy_obj, hmac_HMAC_copy);
+static MP_DEFINE_CONST_FUN_OBJ_2(hmac_HMAC_update_obj, hmac_HMAC_update);
+static MP_DEFINE_CONST_FUN_OBJ_1(hmac_HMAC_digest_obj, hmac_HMAC_digest);
+static MP_DEFINE_CONST_FUN_OBJ_1(hmac_HMAC_copy_obj, hmac_HMAC_copy);
 
-STATIC const mp_rom_map_elem_t hmac_HMAC_locals_dict_table[] = {
+static const mp_rom_map_elem_t hmac_HMAC_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&hmac_HMAC_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_digest), MP_ROM_PTR(&hmac_HMAC_digest_obj) },
     { MP_ROM_QSTR(MP_QSTR_copy), MP_ROM_PTR(&hmac_HMAC_copy_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(hmac_HMAC_locals_dict, hmac_HMAC_locals_dict_table);
+static MP_DEFINE_CONST_DICT(hmac_HMAC_locals_dict, hmac_HMAC_locals_dict_table);
 
-STATIC const mp_obj_type_t hmac_HMAC_type = {
+static const mp_obj_type_t hmac_HMAC_type = {
     { &mp_type_type },
     .name = MP_QSTR_HMAC,
     .make_new = hmac_HMAC_make_new,
@@ -124,25 +124,25 @@ STATIC const mp_obj_type_t hmac_HMAC_type = {
 };
 
 // key, msg=None, digestmod
-STATIC mp_obj_t hmac_new(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+static mp_obj_t hmac_new(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
     return hmac_HMAC_make_new_helper(&hmac_HMAC_type, n_args, args, kwargs);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(hmac_new_obj, 0, hmac_new);
+static MP_DEFINE_CONST_FUN_OBJ_KW(hmac_new_obj, 0, hmac_new);
 
 
 /****************************** MODULE ******************************/
 
-STATIC const mp_rom_map_elem_t hmac_module_globals_table[] = {
+static const mp_rom_map_elem_t hmac_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_hmac) },
     { MP_ROM_QSTR(MP_QSTR_new), MP_ROM_PTR(&hmac_new_obj) },
     { MP_ROM_QSTR(MP_QSTR_HMAC), MP_ROM_PTR(&hmac_new_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(hmac_module_globals, hmac_module_globals_table);
+static MP_DEFINE_CONST_DICT(hmac_module_globals, hmac_module_globals_table);
 
 const mp_obj_module_t hmac_user_cmodule = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&hmac_module_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_hmac, hmac_user_cmodule, MODULE_HASHLIB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_hmac, hmac_user_cmodule);

--- a/uhmac.c
+++ b/uhmac.c
@@ -101,7 +101,7 @@ static mp_obj_t hmac_HMAC_digest(mp_obj_t self_in) {
         vstr_init_len(&vstr, SHA512_DIGEST_LENGTH);
         hmac_sha512_Final((HMAC_SHA512_CTX*)self->state, (byte*)vstr.buf);
     }
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_str_from_vstr(&vstr);
 }
 
 static MP_DEFINE_CONST_FUN_OBJ_2(hmac_HMAC_update_obj, hmac_HMAC_update);
@@ -116,12 +116,20 @@ static const mp_rom_map_elem_t hmac_HMAC_locals_dict_table[] = {
 
 static MP_DEFINE_CONST_DICT(hmac_HMAC_locals_dict, hmac_HMAC_locals_dict_table);
 
-static const mp_obj_type_t hmac_HMAC_type = {
-    { &mp_type_type },
-    .name = MP_QSTR_HMAC,
-    .make_new = hmac_HMAC_make_new,
-    .locals_dict = (void*)&hmac_HMAC_locals_dict,
-};
+// static const mp_obj_type_t hmac_HMAC_type = {
+//     { &mp_type_type },
+//     .name = MP_QSTR_HMAC,
+//     .make_new = hmac_HMAC_make_new,
+//     .locals_dict = (void*)&hmac_HMAC_locals_dict,
+// };
+
+static MP_DEFINE_CONST_OBJ_TYPE(
+    hmac_HMAC_type,
+    MP_QSTR_HMAC,
+    MP_TYPE_FLAG_NONE,
+    make_new, hmac_HMAC_make_new,
+    locals_dict, &hmac_HMAC_locals_dict
+);
 
 // key, msg=None, digestmod
 static mp_obj_t hmac_new(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {

--- a/uhmac.c
+++ b/uhmac.c
@@ -101,7 +101,7 @@ static mp_obj_t hmac_HMAC_digest(mp_obj_t self_in) {
         vstr_init_len(&vstr, SHA512_DIGEST_LENGTH);
         hmac_sha512_Final((HMAC_SHA512_CTX*)self->state, (byte*)vstr.buf);
     }
-    return mp_obj_new_str_from_vstr(&vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 static MP_DEFINE_CONST_FUN_OBJ_2(hmac_HMAC_update_obj, hmac_HMAC_update);


### PR DESCRIPTION
## Changes for MicroPython v1.24.1

* `m_new_obj_var` expects a new input var: `var_field`. See: [b6a9778](https://github.com/micropython/micropython/commit/b6a977848407a4ced45d118cf926bd915cc89dfb#diff-e8376ee061c6b2f436e6f715e89cca9d6c218519d4ce8ac42e659a034871a5d0)
* `mp_obj_new_str_from_vstr` removed an input var. See: [8a0ee5a](https://github.com/micropython/micropython/commit/8a0ee5a5c04e83f04d1c62029ac5ba7c74856507#diff-45db277f7e11d170b9c57e8326c1ec36a46618d67ca7132f183dafb916025d83)
* `STATIC` macro changed to just `static`. See: [decf8e6](https://github.com/micropython/micropython/commit/decf8e6a8bb940d5829ca3296790631fcece7b21)
* `mp_obj_type_t.make_new` removed. See: [94beeab](https://github.com/micropython/micropython/commit/94beeabd2ee179d587942046555833e022241f24#diff-ee9ccce9c2727307cb7b70d3913cec86706ce69182cc42d0a0f5053d79a2fe6cR23)
* `mp_obj_new_str_from_vstr` now checks for utf-8 decoding; return bytes instead via `mp_obj_new_bytes_from_vstr` to avoid `UnicodeError` exceptions.

Misc:
* Update crypto/sha2.c to eliminate warnings about array sizes not matching declarations in crypto/sha.h
* Enable `-O2` compiler performance optimizations.
* README fix for correct `pbkdf2_hmac()` input args.
